### PR TITLE
add codelist for use in filtering on dashboard

### DIFF
--- a/config/migrations/20241106170000-add-type-filters-codelists.graph
+++ b/config/migrations/20241106170000-add-type-filters-codelists.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20241106170000-add-type-filters-codelists.ttl
+++ b/config/migrations/20241106170000-add-type-filters-codelists.ttl
@@ -1,0 +1,76 @@
+# Internal codelist used only inside this application
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mu:   <http://mu.semte.ch/vocabularies/core/>.
+@prefix dvc:  <https://productencatalogus.data.vlaanderen.be/id/concept/Type/> .
+@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .
+@prefix extScheme: <http://mu.semte.ch/vocabularies/ext/conceptscheme/> . 
+@prefix extConcept: <http://mu.semte.ch/vocabularies/ext/concept/> .
+extScheme:Type
+  a                   skos:ConceptScheme ;
+  mu:uuid             "e5669754-3780-4ab0-b813-5a594d44c0f1" ;
+  skos:prefLabel      "Type"@nl ;
+  skos:definition     "Type van een publieke dienst voor filters"@nl ;
+  skos:hasTopConcept  extConcept:AdviesBegeleiding ;
+  skos:hasTopConcept  extConcept:Steunmaatregelen ;
+  skos:hasTopConcept  extConcept:Vergunningen ;
+  skos:hasTopConcept  extConcept:InfrastructuurMateriaal ;
+  skos:hasTopConcept  extConcept:Documenten ;
+  skos:hasTopConcept  extConcept:Belastingen .
+
+extConcept:AdviesBegeleiding
+  a                 skos:Concept ;
+  skos:narrower     dvc:AdviesBegeleiding ;
+  mu:uuid           "f6dc2b52-7793-4beb-bd06-3a8e882d83bb" ;
+  skos:prefLabel    "Advies en begeleiding"@nl ;
+  skos:definition   "Type: Advies en begeleiding"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+extConcept:Steunmaatregelen
+  a                 skos:Concept ;
+  skos:narrower     dvc:FinancieelVoordeel ;
+  mu:uuid           "5e345907-3ab8-450d-b7e1-c97cf1f6ac9f" ;
+  skos:prefLabel    "Steunmaatregelen"@nl ;
+  skos:definition   "Type: Steunmaatregelen"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+extConcept:Vergunningen
+  a                 skos:Concept ;
+  skos:narrower     dvc:Toelating ;
+  mu:uuid           "8d597b37-c6f7-45dd-9de1-c7236e93469c" ;
+  skos:prefLabel    "Vergunningen"@nl ;
+  skos:definition   "Type: Vergunningen"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+extConcept:InfrastructuurMateriaal
+  a                 skos:Concept ;
+  skos:narrower     dvc:InfrastructuurMateriaal ;
+  skos:narrower     dvc:Voorwerp ;
+  mu:uuid           "ecb3bdf7-3d61-436c-83d3-a8f31a08239c" ;
+  skos:prefLabel    "Infrastructuur en materiaal"@nl ;
+  skos:definition   "Type: Beschikbaar stellen van infrastructuur en materiaal"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+extConcept:Documenten
+  a                 skos:Concept ;
+  skos:narrower     dvc:Bewijs ;
+  mu:uuid           "b96816ef-4b57-4df3-97b1-c5a76cdf757a" ;
+  skos:prefLabel    "Documenten"@nl ;
+  skos:definition   "Type: Documenten"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+extConcept:Belastingen
+  a                 skos:Concept ;
+  skos:narrower     dvc:FinancieleVerplichting ;
+  mu:uuid           "fe289e31-dc4b-4726-a656-97f4396641e0" ;
+  skos:prefLabel    "Belastingen"@nl ;
+  skos:definition   "Type: Belastingen"@nl ;
+  skos:inScheme     extScheme:Type ;
+  skos:topConceptOf extScheme:Type .
+
+
+

--- a/config/migrations/20241106180000-add-thema-filters-codelist.graph
+++ b/config/migrations/20241106180000-add-thema-filters-codelist.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20241106180000-add-thema-filters-codelist.ttl
+++ b/config/migrations/20241106180000-add-thema-filters-codelist.ttl
@@ -1,0 +1,145 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dvc:  <https://productencatalogus.data.vlaanderen.be/id/concept/Thema/> .
+@prefix mu:   <http://mu.semte.ch/vocabularies/core/>.
+@prefix extScheme: <http://mu.semte.ch/vocabularies/ext/conceptscheme/> . 
+@prefix extConcept: <http://mu.semte.ch/vocabularies/ext/concept/> .
+
+extScheme:Thema
+    a                   skos:ConceptScheme ;
+    mu:uuid             "cdfdddfd-8d3a-48dd-8013-27f37430ecb5" ;
+    skos:prefLabel      "Thema"@nl ;
+    skos:definition     "Thema van een publieke dienst voor filters"@nl ;
+    skos:hasTopConcept  extConcept:BurgerOverheid ;
+    skos:hasTopConcept  extConcept:WerkenOndernemen ;
+    skos:hasTopConcept  extConcept:Welzijn ;
+    skos:hasTopConcept  extConcept:BouwenWonen ;
+    skos:hasTopConcept  extConcept:Mobiliteit ;
+    skos:hasTopConcept  extConcept:Omgeving ;
+    skos:hasTopConcept  extConcept:VrijeTijd ;
+    skos:hasTopConcept  extConcept:OnderwijsWetenschap ;
+    skos:hasTopConcept  extConcept:Landbouw ;
+    skos:hasTopConcept  extConcept:GemeenteBestuur ;
+    skos:hasTopConcept  extConcept:OnderzoekInnovatie ;
+    skos:hasTopConcept  extConcept:Jeugd ;
+    skos:hasTopConcept  extConcept:Veiligheid ;
+    skos:hasTopConcept  extConcept:EuropaInternationaal .
+
+extConcept:BurgerOverheid
+    a                 skos:Concept ;
+    skos:narrower     dvc:BurgerOverheid ;
+    mu:uuid           "258ffe35-96b4-4ad1-bd2b-e948bb95adc5" ;
+    skos:prefLabel    "Burger en Overheid"@nl ;
+    skos:definition   "Thema: Burger en Overheid"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:WerkenOndernemen
+    a                 skos:Concept ;
+    skos:narrower     dvc:EconomieWerk ;
+    mu:uuid           "d22905f1-283a-414b-96a3-625136f0e7ce" ;
+    skos:prefLabel    "Werken en Ondernemen"@nl ;
+    skos:definition   "Thema: Werken en Ondernemen"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Welzijn
+    a                 skos:Concept ;
+    skos:narrower     dvc:WelzijnGezondheid ;
+    mu:uuid           "dbc31be1-94b1-48a2-8ac9-924acde8994f" ;
+    skos:prefLabel    "Welzijn"@nl ;
+    skos:definition   "Thema: Welzijn"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:BouwenWonen
+    a                 skos:Concept ;
+    skos:narrower     dvc:BouwenWonen ;
+    mu:uuid           "5d564190-0e03-44f8-be73-8c3a70ad4443" ;
+    skos:prefLabel    "Bouwen en Wonen"@nl ;
+    skos:definition   "Thema: Bouwen en Wonen"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Mobiliteit
+    a                 skos:Concept ;
+    skos:narrower     dvc:MobiliteitOpenbareWerken ;
+    mu:uuid           "f3e332f4-62ad-446f-bf37-e982c69de8e1" ;
+    skos:prefLabel    "Mobiliteit"@nl ;
+    skos:definition   "Thema: Mobiliteit"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Omgeving
+    a                 skos:Concept ;
+    skos:narrower     dvc:MilieuEnergie ;
+    mu:uuid           "84d91754-0512-48f7-b783-f5a842122016" ;
+    skos:prefLabel    "Omgeving"@nl ;
+    skos:definition   "Thema: Omgeving"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:VrijeTijd
+    a                 skos:Concept ;
+    skos:narrower     dvc:CultuurSportVrijeTijd ;
+    mu:uuid           "d6fe7cc4-cc3e-4650-a05f-f0209bc68ef5" ;
+    skos:prefLabel    "Vrije Tijd"@nl ;
+    skos:definition   "Thema: Vrije Tijd"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Onderwijs
+    a                 skos:Concept ;
+    skos:narrower     dvc:OnderwijsWetenschap ;
+    mu:uuid           "803a7566-e55b-4ae2-b2ee-4edcc953c3e1" ;
+    skos:prefLabel    "Onderwijs"@nl ;
+    skos:definition   "Thema: Onderwijs"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Landbouw
+    a                 skos:Concept ;
+    mu:uuid           "b866f1f7-eb66-4ef9-8a69-9edf0a85ef08" ;
+    skos:prefLabel    "Landbouw"@nl ;
+    skos:definition   "Thema: Landbouw"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .    
+
+extConcept:GemeenteBestuur
+    a                 skos:Concept ;
+    mu:uuid           "57268c8a-7eb5-45f5-a45b-2d3201c488bf" ;
+    skos:prefLabel    "Gemeente en Bestuur"@nl ;
+    skos:definition   "Thema: Gemeente en Bestuur"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:OnderzoekInnovatie
+    a                 skos:Concept ;
+    mu:uuid           "c501cbf3-cb9d-457d-b20d-a3452c7ecdc6" ;
+    skos:prefLabel    "Onderzoek en Innovatie"@nl ;
+    skos:definition   "Thema: Onderzoek en Innovatie"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Jeugd
+    a                 skos:Concept ;
+    mu:uuid           "ca55e663-89ec-4578-86c9-93ccbd1c2d3d" ;
+    skos:prefLabel    "Jeugd"@nl ;
+    skos:definition   "Thema: Jeugd"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:Veiligheid
+    a                 skos:Concept ;
+    mu:uuid           "ef04b97b-6c16-4e62-a862-1748b9c7337e" ;
+    skos:prefLabel    "Veiligheid"@nl ;
+    skos:definition   "Thema: Veiligheid"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .
+
+extConcept:EuropaInternationaal
+    a                 skos:Concept ;
+    mu:uuid           "85c9d29f-c407-446e-a4cf-4cba4a357802" ;
+    skos:prefLabel    "Europa en internationaal"@nl ;
+    skos:definition   "Thema: Europa en internationaal"@nl ;
+    skos:inScheme     extScheme:Thema ;
+    skos:topConceptOf extScheme:Thema .    

--- a/config/migrations/20241106200000-add-filters-bevoegd-bestuursniveau.graph
+++ b/config/migrations/20241106200000-add-filters-bevoegd-bestuursniveau.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/20241106200000-add-filters-bevoegd-bestuursniveau.ttl
+++ b/config/migrations/20241106200000-add-filters-bevoegd-bestuursniveau.ttl
@@ -1,0 +1,63 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dvc:  <https://productencatalogus.data.vlaanderen.be/id/concept/BevoegdBestuursniveau/> .
+@prefix mu:   <http://mu.semte.ch/vocabularies/core/>.
+@prefix extScheme: <http://mu.semte.ch/vocabularies/ext/conceptscheme/> . 
+@prefix extConcept: <http://mu.semte.ch/vocabularies/ext/concept/> .
+
+extScheme:BevoegdBestuursniveau
+    a                   skos:ConceptScheme ;
+    mu:uuid             "445e1e4d-7ef0-4de2-b022-5af455258559" ;
+    skos:prefLabel      "Bevoegd bestuursniveau"@nl ;
+    skos:prefLabel      "Competent authority level"@en ;
+    skos:definition     "Bevoegd bestuursniveau van een publieke dienst voor filters"@nl ;
+    skos:definition     "Competent autority level of a public service for filtering"@en ;
+    skos:hasTopConcept  extConcept:Europees ;
+    skos:hasTopConcept  extConcept:Federaal ;
+    skos:hasTopConcept  extConcept:Vlaams ;
+    skos:hasTopConcept  extConcept:Provinciaal ;
+    skos:hasTopConcept  extConcept:Lokaal .
+
+extConcept:Europees
+    a                 skos:Concept ;
+    skos:narrower     dvc:Europees ;
+    mu:uuid           "e2f21435-0ec7-4190-8bed-89f6275475e7" ;
+    skos:prefLabel    "Europees"@nl ;
+    skos:definition   "Bevoegd bestuursniveau: Europees"@nl ;
+    skos:inScheme     extScheme:BevoegdBestuursniveau ;
+    skos:topConceptOf extScheme:BevoegdBestuursniveau .
+
+extConcept:Federaal
+    a                 skos:Concept ;
+    skos:narrower     dvc:Federaal ;
+    mu:uuid           "02dd97f6-4d00-4933-b235-e27e18ce7069" ;
+    skos:prefLabel    "Federaal"@nl ;
+    skos:definition   "Bevoegd bestuursniveau: Federaal"@nl ;
+    skos:inScheme     extScheme:BevoegdBestuursniveau ;
+    skos:topConceptOf extScheme:BevoegdBestuursniveau .
+
+extConcept:Vlaams
+    a                 skos:Concept ;
+    skos:narrower     dvc:Vlaams ;
+    mu:uuid           "ccf5d092-43e5-4e49-a3ce-f45b7e65a074" ;
+    skos:prefLabel    "Vlaams"@nl ;
+    skos:definition   "Bevoegd bestuursniveau: Vlaams"@nl ;
+    skos:inScheme     extScheme:BevoegdBestuursniveau ;
+    skos:topConceptOf extScheme:BevoegdBestuursniveau .
+
+extConcept:Provinciaal
+    a                 skos:Concept ;
+    skos:narrower     dvc:Provinciaal ;
+    mu:uuid           "493d3df1-a79d-4c15-a07d-5ce69fc655a2" ;
+    skos:prefLabel    "Provinciaal"@nl ;
+    skos:definition   "Bevoegd bestuursniveau: Provinciaal"@nl ;
+    skos:inScheme     extScheme:BevoegdBestuursniveau ;
+    skos:topConceptOf extScheme:BevoegdBestuursniveau .
+
+extConcept:Lokaal
+    a                 skos:Concept ;
+    skos:narrower     dvc:Lokaal ;
+    mu:uuid           "3f863c42-5b8d-412a-aee2-3d184cf93b89" ;
+    skos:prefLabel    "Lokaal"@nl ;
+    skos:definition   "Bevoegd bestuursniveau: Lokaal"@nl ;
+    skos:inScheme     extScheme:BevoegdBestuursniveau ;
+    skos:topConceptOf extScheme:BevoegdBestuursniveau .

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -28,7 +28,12 @@
   :has-many `((concept-scheme :via ,(s-prefix "skos:inScheme")
                               :as "concept-schemes")
               (concept-scheme :via ,(s-prefix "skos:topConceptOf")
-                              :as "top-concept-schemes"))
+                              :as "top-concept-schemes")
+              (concept :via ,(s-prefix "skos:narrower")
+                       :as "narrower")
+              (concept :via ,(s-prefix "skos:narrower")
+                       :inverse t         
+                       :as "broader"))
   :resource-base (s-url "http://lblod.data.gift/concepts/")
   :features `(include-uri)
   :on-path "concepts"


### PR DESCRIPTION
These codelists refer to the actual URI that is used in product catalog via skos:narrower. These codelists are purely for internal use in the frontend

see https://github.com/lblod/frontend-poc-future-loket-hoofdloket/pull/2 for usage of these codelists